### PR TITLE
feat: number of upload nodes is configurable

### DIFF
--- a/check.js
+++ b/check.js
@@ -3,7 +3,7 @@
 const { Bee } = require('@ethersphere/bee-js')
 
 const BEE_HOSTS = (process.env.BEE_HOSTS && process.env.BEE_HOSTS.split(',')) || ['http://localhost:1633']
-const bees = BEE_HOSTS.map(host => new Bee(host))
+const bees = BEE_HOSTS.filter(host => host.length !== 0).map(host => new Bee(host))
 
 async function tryRetrieveHash(bee, hash) {
   const start = Date.now()

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,51 @@
   "requires": true,
   "dependencies": {
     "@ethersphere/bee-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-1.1.1.tgz",
-      "integrity": "sha512-kA8Wl0xhtYbJBaTpX5noEPl1tWFVaKByver2Qc2FTu6AqwFD4LM4djuVYh1LsanaTluyO6ms4tvqxzTKVseviw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-3.0.0.tgz",
+      "integrity": "sha512-Z08qnpFT8vTui93KLEu+HAB/Lkc8yVv1xGv642iR80kH0itmg0PrJ8hukirSyGV82LJ/YrGGd+Lx63ntzH61vA==",
       "requires": {
-        "axios": "^0.21.1",
+        "@types/readable-stream": "^2.3.11",
+        "bufferutil": "^4.0.3",
+        "cross-blob": "^2.0.1",
         "elliptic": "^6.5.4",
         "isomorphic-ws": "^4.0.1",
         "js-sha3": "^0.8.0",
+        "ky": "^0.25.1",
+        "ky-universal": "^0.8.2",
+        "readable-stream": "^3.6.0",
         "tar-js": "^0.3.0",
+        "utf-8-validate": "^5.0.5",
+        "web-streams-polyfill": "^3.1.0",
         "ws": "^7.5.0"
       }
     },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+    "@types/node": {
+      "version": "16.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
+      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
+    },
+    "@types/readable-stream": {
+      "version": "2.3.12",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.12.tgz",
+      "integrity": "sha512-IVe0ietigIRWjRg0gv2sydr0rhyPzdXQsBMU/gda8fl82xQL+J9UWRBcD0asxoe4pb5wTOsPrOz0KYJZVCXZJQ==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "@types/node": "*",
+        "safe-buffer": "*"
       }
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "blob-polyfill": {
+      "version": "5.0.20210201",
+      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-5.0.20210201.tgz",
+      "integrity": "sha512-SrH6IG6aXL9pCgSysBCiDpGcAJ1j6/c1qCwR3sTEQJhb+MTk6FITNA6eW6WNYQDNZVi4Z9GjxH5v2MMTv59CrQ=="
     },
     "bn.js": {
       "version": "4.12.0",
@@ -34,6 +60,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "bufferutil": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
+      "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "cross-blob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cross-blob/-/cross-blob-2.0.1.tgz",
+      "integrity": "sha512-ARuKPPo3I6DSqizal4UCyMCiGPQdMpMJS3Owx6Lleuh26vSt2UnfWRwbMLCYqbJUrcol+KzGVSLR91ezSHP80A==",
+      "requires": {
+        "blob-polyfill": "^5.0.20210201",
+        "fetch-blob": "^2.1.2"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -49,10 +97,15 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "fetch-blob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
+      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
     },
     "hash.js": {
       "version": "1.1.7",
@@ -88,6 +141,20 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
+    "ky": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
+      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
+    },
+    "ky-universal": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
+      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "3.0.0-beta.9"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -98,15 +165,70 @@
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
+    "node-fetch": {
+      "version": "3.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
+      "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
+      "requires": {
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^2.1.1"
+      }
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "tar-js": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/tar-js/-/tar-js-0.3.0.tgz",
       "integrity": "sha1-aUmqv7C6GLsVYq5RpDn9DzAYOhc="
     },
+    "utf-8-validate": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
+      "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
+    },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ethersphere/bee-js": "^1.1.1"
+    "@ethersphere/bee-js": "3.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ async function retrieveAll(bees, hash) {
   })
 }
 
-async function retrieveHashFromAll(hash) {
+async function retriveWithReport(bees, hash) {
   const start = Date.now()
 
   await retrieveAll(bees, hash)
@@ -101,12 +101,16 @@ async function uploadAndCheck() {
 
   const randomFunc = makeRandomFuncFromSeed(seedBytes)
   const randomBees = randomShuffle(bees, randomFunc)
-  const randomBee = randomBees[0]
+  const numUploadNodes = 2
+  const uploadBees = randomBees.slice(0, numUploadNodes)
+  const downloadBees = randomBees.slice(numUploadNodes)
 
-  const hash = await uploadToRandomBee(randomBee, seedBytes)
+  const hashes = await Promise.all(uploadBees.map(bee => uploadToRandomBee(bee, seedBytes)))
   setTimeout(() => { console.error(`Timeout after ${TIMEOUT} secs`); exitWithReport(1) }, TIMEOUT * 1000)
 
-  await retrieveHashFromAll(hash)
+  console.log({hashes})
+
+  await retriveWithReport(downloadBees, hashes[0])
   exitWithReport(0)
 }
 

--- a/upload-report.js
+++ b/upload-report.js
@@ -1,0 +1,34 @@
+const { Bee } = require('@ethersphere/bee-js')
+const { readFileSync } = require('fs')
+
+const POSTAGE_STAMP = process.env.POSTAGE_STAMP || '0000000000000000000000000000000000000000000000000000000000000000'
+const TOPIC = '0000000000000000000000000000000000000000000000000000000000000000'
+
+async function upload() {
+    const beeUrl = process.argv[2] || process.env.BEE_URL
+    const feedKey = process.argv[3] || process.env.FEED_KEY
+
+    const bee = new Bee(beeUrl)
+
+    const reportFileName = 'report.csv'
+    const file = readFileSync(reportFileName)
+
+    try {
+        const response = await bee.uploadFile(POSTAGE_STAMP, file, reportFileName, { contentType: 'text/csv' })
+        console.log(`Reference: ${response.reference}/`)
+
+        const reference = response.reference
+        const feedWriter = bee.makeFeedWriter('sequence', TOPIC, feedKey)
+        const feedResponse = await feedWriter.upload(POSTAGE_STAMP, reference)
+        const feedUpdate = await feedWriter.download()
+        const feedReference = await bee.createFeedManifest(POSTAGE_STAMP, 'sequence', TOPIC, feedWriter.owner)
+        console.log(`Feed address: ${feedWriter.owner}`)
+        console.log(`Feed topic: ${feedWriter.topic}`)
+        console.log(`Feed index: ${feedUpdate.feedIndex}`)
+        console.log(`${bee.url}/bzz/${feedReference}/`)
+    } catch (e) {
+        console.error(e)
+    }
+}
+
+upload().catch(console.error)

--- a/util.js
+++ b/util.js
@@ -22,6 +22,7 @@ async function retry(asyncFn, minSleep = 60_000) {
     try {
       return await asyncFn()
     } catch (e) {
+      console.error({e})
       const sleepTime = typeof minSleep === 'number' ? minSleep : minSleep()
       await sleep(Math.floor(sleepTime + Math.random() * sleepTime))
     }
@@ -37,7 +38,7 @@ async function timeout(asyncFn, timeoutMsec) {
 }
 
 function randomFromBytes(randomBytes) {
-  const hex = Utils.Hex.bytesToHex(randomBytes).slice(0, 8)
+  const hex = Utils.bytesToHex(randomBytes).slice(0, 8)
   const num = parseInt(hex, 16)
   return num / 0x100000000
 }
@@ -77,7 +78,7 @@ function makeRandomFuncFromSeed(seedBytes) {
 }
 
 function formatDateTime(date) {
-  return date.toISOString().replace('T', ' ').slice(0, 16)
+  return date.toISOString().replace('T', ' ').slice(0, 19)
 }
 
 module.exports = { formatDateTime, makeRandomFuncFromSeed, randomShuffle, generateRandomArray, retry, timeout, expBackoff}


### PR DESCRIPTION
By making `numUploadNodes` configurable it is possible to test different scenarios. For example changing it to `5` would make the script to upload the same chunk for the first 5 nodes from a randomised list of nodes and try the retrieval from the rest of them.

It seems that increasing the number of `numUploadNodes` increases the success of retrieval metric significantly.